### PR TITLE
fix: prevent multiple submits

### DIFF
--- a/public/form.html
+++ b/public/form.html
@@ -99,6 +99,8 @@
             })
 
             const form = document.querySelector("form");
+            const button = document.querySelector("button");
+
             form.addEventListener("change", event => {
                 if (event.target.type === "radio" && event.target.parentElement && event.target.parentElement.tagName.toLowerCase() === "label") {
                     const prior = form.querySelector('label.checked input[name="' + event.target.name + '"]');
@@ -107,6 +109,11 @@
                     }
                     event.target.parentElement.classList.add( "checked" );
                 }
+            }, false);
+
+            form.addEventListener("submit", () => {
+                button.disabled = true;
+                button.textContent = "Submitting...";
             }, false);
         </script>
     </body>


### PR DESCRIPTION
This PR solves a problem I have often encountered - when clicking a button instead of waiting, someone was able to send several of the same appeals. When submitting the form, the button is disabled and the user is informed that the form is being submitted.