### PR TITLE
feat: Webhook URLs (#17)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ By using OAuth2, it ensures users can't forge or fake appeals.
    | Client ID             | You can get this from the **General Information** section for the application you created in step 1.                       |
    | Client secret         | You can get this from the **General Information** section for the application you created in step 1.                       |
    | Bot token             | Get this in the **Bot** section that you used in step 2.                                                                   |
+   | Webhook URL           | You can create it in Discord Channel Settings -> Integrations -> Webhooks                                                  |
    | Guild ID              | This is where the developer mode you enabled in step 4 comes in handy. Right-click your server icon and press **Copy ID**. |
    | Channel ID            | Same deal than the guild ID, but with the channel you created in step 3.                                                   |
    | JSON Web Token secret | Use a password manager to generate a password with ~50 characters, or mash your keyboard.                                  |
@@ -43,6 +44,10 @@ By using OAuth2, it ensures users can't forge or fake appeals.
 12. Hit the green **Save Changes** button.
 
 13. You should be good to go! You might want to test if it works as intended with an alt account, and if you encounter any problems feel free to [create an issue on GitHub](https://github.com/sylveon/discord-ban-appeals/issues/new).
+
+## Using webhooks
+
+When you use the `DISCORD_WEBHOOK_URL`, you don't need to specify the `DISCORD_BOT_TOKEN`, `GUILD_ID`, and `APPEALS_CHANNEL` in the environment variables. The message will be sent using the webhook without an unban button.
 
 ## Blocking users
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ By using OAuth2, it ensures users can't forge or fake appeals.
    | Client ID             | You can get this from the **General Information** section for the application you created in step 1.                       |
    | Client secret         | You can get this from the **General Information** section for the application you created in step 1.                       |
    | Bot token             | Get this in the **Bot** section that you used in step 2.                                                                   |
-   | Webhook URL           | You can create it in Discord Channel Settings -> Integrations -> Webhooks                                                  |
    | Guild ID              | This is where the developer mode you enabled in step 4 comes in handy. Right-click your server icon and press **Copy ID**. |
    | Channel ID            | Same deal than the guild ID, but with the channel you created in step 3.                                                   |
    | JSON Web Token secret | Use a password manager to generate a password with ~50 characters, or mash your keyboard.                                  |
@@ -45,10 +44,6 @@ By using OAuth2, it ensures users can't forge or fake appeals.
 
 13. You should be good to go! You might want to test if it works as intended with an alt account, and if you encounter any problems feel free to [create an issue on GitHub](https://github.com/sylveon/discord-ban-appeals/issues/new).
 
-## Using webhooks
-
-When you use the `DISCORD_WEBHOOK_URL`, you don't need to specify the `DISCORD_BOT_TOKEN`, `GUILD_ID`, and `APPEALS_CHANNEL` in the environment variables. The message will be sent using the webhook without an unban button.
-
 ## Blocking users
 
 Users that spam requests can be blocked by creating an environment variable called `BLOCKED_USERS`, which should contain a comma-separated list of quoted user IDs. To do this:
@@ -66,3 +61,17 @@ Users that spam requests can be blocked by creating an environment variable call
    ![](https://i.imgur.com/jNKgS2B.png)
 
 6. Redeploy the site with **Deploys** -> **Trigger deploy** -> **Deploy site**.
+
+## Using webhooks
+
+When you use the `DISCORD_WEBHOOK_URL`, you don't need to specify the `DISCORD_BOT_TOKEN`, `GUILD_ID`, and `APPEALS_CHANNEL` in the environment variables. The message will be sent using the webhook without an unban button. To do this:
+
+1. On your [Netlify dashboard](https://app.netlify.com), click **Deploys** and navigate to **Deploy settings**, and then to the **Environment** option.
+
+2. Under **Environment variables**, click **Edit variables**.
+
+3. Right-click on any channel and click **Edit Channel** -> **Integrations** -> **Webhooks** -> **Copy Webhook URL**.
+
+4. Click **New variable**, and create an environment variable with `DISCORD_WEBHOOK_URL` as its key. For the value, paste the Webhook URL you copied in the previous step.
+
+5. Redeploy the site with **Deploys** -> **Trigger deploy** -> **Deploy site**.

--- a/build.js
+++ b/build.js
@@ -44,15 +44,17 @@ async function main() {
         fs.unlink(path.resolve(func, "unban.js"), assertSuccess);
     }
 
-    // Make sure the bot connected to the gateway at least once.
-    const bot = new Eris(process.env.DISCORD_BOT_TOKEN);
-    bot.on("ready", () => bot.disconnect());
-    
-    try {
-        await bot.connect();
-    } catch (e) {
-        console.log(e);
-        process.exit(1);
+    if(!process.env.DISCORD_WEBHOOK_URL) {
+        // Make sure the bot connected to the gateway at least once.
+        const bot = new Eris(process.env.DISCORD_BOT_TOKEN);
+        bot.on("ready", () => bot.disconnect());
+
+        try {
+            await bot.connect();
+        } catch (e) {
+            console.log(e);
+            process.exit(1);
+        }
     }
 }
 

--- a/build.js
+++ b/build.js
@@ -40,7 +40,7 @@ async function main() {
         }
     });
 
-    if (process.env.DISABLE_UNBAN_LINK) {
+    if (process.env.DISABLE_UNBAN_LINK || process.env.DISCORD_WEBHOOK_URL) {
         fs.unlink(path.resolve(func, "unban.js"), assertSuccess);
     }
 

--- a/func/oauth-callback.js
+++ b/func/oauth-callback.js
@@ -62,7 +62,7 @@ export async function handler(event, context) {
                 };
             }
     
-            if (process.env.GUILD_ID && !process.env.SKIP_BAN_CHECK) {
+            if (process.env.GUILD_ID && !process.env.SKIP_BAN_CHECK && !process.env.DISCORD_WEBHOOK_URL) {
                 const ban = await getBan(user.id, process.env.GUILD_ID, process.env.DISCORD_BOT_TOKEN);
                 if (ban === null) {
                     return {

--- a/netlify.toml
+++ b/netlify.toml
@@ -16,7 +16,6 @@
   DISCORD_CLIENT_ID = "Your Discord App's client ID"
   DISCORD_CLIENT_SECRET = "Your Discord App's client secret"
   DISCORD_BOT_TOKEN = "Your Discord Bot Token"
-  DISCORD_WEBHOOK_URL = "Your Discord Webhook URL"
   GUILD_ID = "ID of the guild this deployment targets"
   APPEALS_CHANNEL = "ID of the channel used for appeal form submission"
   JWT_SECRET = "JSON Web Token secret, mash keyboard plz"

--- a/netlify.toml
+++ b/netlify.toml
@@ -16,7 +16,7 @@
   DISCORD_CLIENT_ID = "Your Discord App's client ID"
   DISCORD_CLIENT_SECRET = "Your Discord App's client secret"
   DISCORD_BOT_TOKEN = "Your Discord Bot Token"
+  DISCORD_WEBHOOK_URL = "Your Discord Webhook URL"
   GUILD_ID = "ID of the guild this deployment targets"
   APPEALS_CHANNEL = "ID of the channel used for appeal form submission"
-  DISCORD_WEBHOOK_URL = "Your Discord Webhook URL (if used, fill only JWT_SECRET)"
   JWT_SECRET = "JSON Web Token secret, mash keyboard plz"

--- a/netlify.toml
+++ b/netlify.toml
@@ -16,7 +16,7 @@
   DISCORD_CLIENT_ID = "Your Discord App's client ID"
   DISCORD_CLIENT_SECRET = "Your Discord App's client secret"
   DISCORD_BOT_TOKEN = "Your Discord Bot Token"
-  DISCORD_WEBHOOK_URL = "Your Discord Webhook URL (if used, only a message is sent to the channel)"
   GUILD_ID = "ID of the guild this deployment targets"
   APPEALS_CHANNEL = "ID of the channel used for appeal form submission"
+  DISCORD_WEBHOOK_URL = "Your Discord Webhook URL (if used, fill only JWT_SECRET)"
   JWT_SECRET = "JSON Web Token secret, mash keyboard plz"

--- a/netlify.toml
+++ b/netlify.toml
@@ -16,6 +16,7 @@
   DISCORD_CLIENT_ID = "Your Discord App's client ID"
   DISCORD_CLIENT_SECRET = "Your Discord App's client secret"
   DISCORD_BOT_TOKEN = "Your Discord Bot Token"
+  DISCORD_WEBHOOK_URL = "Your Discord Webhook URL (if used, only a message is sent to the channel)"
   GUILD_ID = "ID of the guild this deployment targets"
   APPEALS_CHANNEL = "ID of the channel used for appeal form submission"
   JWT_SECRET = "JSON Web Token secret, mash keyboard plz"

--- a/public/form.html
+++ b/public/form.html
@@ -56,7 +56,7 @@
                 const jsonPayload = decodeURIComponent(atob(base64).split('').map(c => '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)).join(''));
 
                 return JSON.parse(jsonPayload);
-            };
+            }
 
             const params = new URLSearchParams(document.location.search.substring(1));
             if (!params.has("token")) {


### PR DESCRIPTION
Using `DISCORD_WEBHOOK_URL` in the environment variables allows you to send messages via the webhook URL instead of performing the ban check and sending messages using the bot token. When the webhook URL is used, the message is sent without an unban button. 

I think it can be added as an optional way to create an appeal (without any bot-related things).
This also could be easy modified to be thing of other types of appeals.
This closes issue #17.