### PR TITLE
Remove Eris from dependencies

### DIFF
--- a/build.js
+++ b/build.js
@@ -47,19 +47,16 @@ async function main() {
 
     if(!process.env.DISCORD_WEBHOOK_URL) {
         // Make sure the bot token & env variables are valid.
-        const headers = {
-            "Authorization": `Bot ${process.env.DISCORD_BOT_TOKEN}`,
+        const init = {
+            method: "GET",
+            headers: {
+                "Authorization": `Bot ${process.env.DISCORD_BOT_TOKEN}`,
+            },
         };
 
         const results = await Promise.all([
-            fetch(`${API_ENDPOINT}/guilds/${process.env.GUILD_ID}/bans?limit=1`, {
-                method: "GET",
-                headers: headers,
-            }),
-           fetch(`${API_ENDPOINT}/channels/${process.env.APPEALS_CHANNEL}`, {
-                method: "GET",
-                headers: headers,
-            }),
+            fetch(`${API_ENDPOINT}/guilds/${process.env.GUILD_ID}/bans?limit=1`, init),
+            fetch(`${API_ENDPOINT}/channels/${process.env.APPEALS_CHANNEL}`, init),
         ]);
 
         results.forEach(result => {

--- a/build.js
+++ b/build.js
@@ -3,7 +3,7 @@ import fs from "fs";
 import path from "path";
 import process from "process";
 import { fileURLToPath } from 'url';
-import {API_ENDPOINT} from "./func/helpers/discord-helpers.js";
+import { API_ENDPOINT } from "./func/helpers/discord-helpers.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
     "packages": {
         "": {
             "dependencies": {
-                "eris": "^0.16.1",
                 "jsonwebtoken": "^9.0.0",
                 "node-fetch": "^3.2.10"
             }
@@ -29,21 +28,6 @@
             "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
             "dependencies": {
                 "safe-buffer": "^5.0.1"
-            }
-        },
-        "node_modules/eris": {
-            "version": "0.16.1",
-            "resolved": "https://registry.npmjs.org/eris/-/eris-0.16.1.tgz",
-            "integrity": "sha512-fqjgaddSvUlUjA7s85OvZimLrgCwX58Z6FXOIxdNFJdT6XReJ/LOWZKdew2CaalM8BvN2JKzn98HmKYb3zMhKg==",
-            "dependencies": {
-                "ws": "^8.2.3"
-            },
-            "engines": {
-                "node": ">=10.4.0"
-            },
-            "optionalDependencies": {
-                "opusscript": "^0.0.8",
-                "tweetnacl": "^1.0.3"
             }
         },
         "node_modules/fetch-blob": {
@@ -169,12 +153,6 @@
                 "url": "https://opencollective.com/node-fetch"
             }
         },
-        "node_modules/opusscript": {
-            "version": "0.0.8",
-            "resolved": "https://registry.npmjs.org/opusscript/-/opusscript-0.0.8.tgz",
-            "integrity": "sha512-VSTi1aWFuCkRCVq+tx/BQ5q9fMnQ9pVZ3JU4UHKqTkf0ED3fKEPdr+gKAAl3IA2hj9rrP6iyq3hlcJq3HELtNQ==",
-            "optional": true
-        },
         "node_modules/safe-buffer": {
             "version": "5.2.1",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -208,38 +186,12 @@
                 "node": ">=10"
             }
         },
-        "node_modules/tweetnacl": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-            "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
-            "optional": true
-        },
         "node_modules/web-streams-polyfill": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.0.tgz",
             "integrity": "sha512-EqPmREeOzttaLRm5HS7io98goBgZ7IVz79aDvqjD0kYXLtFZTc0T/U6wHTPKyIjb+MdN7DFIIX6hgdBEpWmfPA==",
             "engines": {
                 "node": ">= 8"
-            }
-        },
-        "node_modules/ws": {
-            "version": "8.17.1",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-            "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
-            "engines": {
-                "node": ">=10.0.0"
-            },
-            "peerDependencies": {
-                "bufferutil": "^4.0.1",
-                "utf-8-validate": ">=5.0.2"
-            },
-            "peerDependenciesMeta": {
-                "bufferutil": {
-                    "optional": true
-                },
-                "utf-8-validate": {
-                    "optional": true
-                }
             }
         },
         "node_modules/yallist": {
@@ -265,16 +217,6 @@
             "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
             "requires": {
                 "safe-buffer": "^5.0.1"
-            }
-        },
-        "eris": {
-            "version": "0.16.1",
-            "resolved": "https://registry.npmjs.org/eris/-/eris-0.16.1.tgz",
-            "integrity": "sha512-fqjgaddSvUlUjA7s85OvZimLrgCwX58Z6FXOIxdNFJdT6XReJ/LOWZKdew2CaalM8BvN2JKzn98HmKYb3zMhKg==",
-            "requires": {
-                "opusscript": "^0.0.8",
-                "tweetnacl": "^1.0.3",
-                "ws": "^8.2.3"
             }
         },
         "fetch-blob": {
@@ -357,12 +299,6 @@
                 "formdata-polyfill": "^4.0.10"
             }
         },
-        "opusscript": {
-            "version": "0.0.8",
-            "resolved": "https://registry.npmjs.org/opusscript/-/opusscript-0.0.8.tgz",
-            "integrity": "sha512-VSTi1aWFuCkRCVq+tx/BQ5q9fMnQ9pVZ3JU4UHKqTkf0ED3fKEPdr+gKAAl3IA2hj9rrP6iyq3hlcJq3HELtNQ==",
-            "optional": true
-        },
         "safe-buffer": {
             "version": "5.2.1",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -376,22 +312,10 @@
                 "lru-cache": "^6.0.0"
             }
         },
-        "tweetnacl": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-            "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
-            "optional": true
-        },
         "web-streams-polyfill": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.0.tgz",
             "integrity": "sha512-EqPmREeOzttaLRm5HS7io98goBgZ7IVz79aDvqjD0kYXLtFZTc0T/U6wHTPKyIjb+MdN7DFIIX6hgdBEpWmfPA=="
-        },
-        "ws": {
-            "version": "8.17.1",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-            "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
-            "requires": {}
         },
         "yallist": {
             "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
     "type": "module",
     "dependencies": {
-        "eris": "^0.16.1",
         "jsonwebtoken": "^9.0.0",
         "node-fetch": "^3.2.10"
     }


### PR DESCRIPTION
This PR removes Eris from dependencies - it is not needed, additional verification of the token and the validity of the ban permissions / channel is done by two simple `fetch`.

- removed unnecessary dependency
- additional verification of the possibility of checking bans
- additional verification that the channel exists