### PR TITLE
Ban reason & block flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,23 @@ Users that spam requests can be blocked by creating an environment variable call
 
 6. Redeploy the site with **Deploys** -> **Trigger deploy** -> **Deploy site**.
 
+### Discord user block
+
+Users can also be banned by adding `/p` or `/perm` to the Discord ban reason.
+
+## Hiding the ban reason
+
+By default, the ban reason is displayed until `/h` or `/hide` is added to it. To globally disable the ban reason follow the steps below:
+
+1. On your [Netlify dashboard](https://app.netlify.com), click **Deploys** and navigate to **Deploy settings**, and then to the **Environment** option.
+
+2. Under **Environment variables**, click **Edit variables**.
+
+3. Click **New variable**, and create an environment variable with `ALWAYS_HIDE_BAN_REASON` as its key. Use `true` as the value.
+
+4. Redeploy the site with **Deploys** -> **Trigger deploy** -> **Deploy site**.
+
+
 ## Using webhooks
 
 When you use the `DISCORD_WEBHOOK_URL`, you don't need to specify the `DISCORD_BOT_TOKEN`, `GUILD_ID`, and `APPEALS_CHANNEL` in the environment variables. The message will be sent using the webhook without an unban button. To do this:

--- a/func/oauth-callback.js
+++ b/func/oauth-callback.js
@@ -61,6 +61,13 @@ export async function handler(event, context) {
                     },
                 };
             }
+
+            const userPublic = {
+                id: user.id,
+                avatar: user.avatar,
+                username: user.username,
+                discriminator: user.discriminator
+            };
     
             if (process.env.GUILD_ID && !process.env.SKIP_BAN_CHECK && !process.env.DISCORD_WEBHOOK_URL) {
                 const ban = await getBan(user.id, process.env.GUILD_ID, process.env.DISCORD_BOT_TOKEN);
@@ -72,15 +79,25 @@ export async function handler(event, context) {
                         }
                     };
                 }
+
+                if (ban.reason) {
+                    if (ban.reason.includes("/p") || ban.reason.includes("/perm")) {
+                        return {
+                            statusCode: 303,
+                            headers: {
+                                "Location": `/error?msg=${encodeURIComponent("You cannot submit ban appeals with this Discord account.")}`,
+                            },
+                        };
+                    }
+
+                    if (!process.env.ALWAYS_HIDE_BAN_REASON) {
+                        if(!ban.reason.includes("/h") && !ban.reason.includes("/hide")) {
+                            userPublic.reason = ban.reason;
+                        }
+                    }
+                }
             }
-    
-            const userPublic = {
-                id: user.id,
-                avatar: user.avatar,
-                username: user.username,
-                discriminator: user.discriminator
-            };
-    
+
             return {
                 statusCode: 303,
                 headers: {

--- a/func/submission-created.js
+++ b/func/submission-created.js
@@ -40,8 +40,7 @@ export async function handler(event, context) {
             };
         }
 
-        const isPomelo = userInfo.discriminator === "0";
-        const username = isPomelo ? userInfo.username : `${userInfo.username}#${userInfo.discriminator}`;
+        const username = userInfo.username;
 
         const message = {
             embed: {

--- a/func/submission-created.js
+++ b/func/submission-created.js
@@ -40,8 +40,6 @@ export async function handler(event, context) {
             };
         }
 
-        const username = userInfo.username;
-
         const message = {
             embed: {
                 title: "New appeal submitted!",
@@ -49,7 +47,7 @@ export async function handler(event, context) {
                 fields: [
                     {
                         name: "Submitter",
-                        value: `<@${userInfo.id}> (${username})`
+                        value: `<@${userInfo.id}> (${userInfo.username})`
                     },
                     {
                         name: "Why were you banned?",

--- a/public/form.html
+++ b/public/form.html
@@ -66,14 +66,12 @@
             const jwt = params.get("token");
             const userInfo = parseJwt(jwt);
 
-            const isPomelo = userInfo.discriminator === "0";
-
             const avatar = userInfo.avatar
                 ? `avatars/${encodeURIComponent(userInfo.id)}/${encodeURIComponent(userInfo.avatar)}.webp`
-                : `embed/avatars/${isPomelo ? (Number(BigInt(userInfo.id) >> 22n) % 6) : (userInfo.discriminator % 5)}.png`;
+                : `embed/avatars/${Number(BigInt(userInfo.id) >> 22n) % 6}.png`;
             document.getElementById("avatar").src = `https://cdn.discordapp.com/${avatar}?size=256`;
 
-            document.getElementById("username").textContent = isPomelo ? userInfo.username : `${userInfo.username}#${userInfo.discriminator}`;
+            document.getElementById("username").textContent = userInfo.username;
 
             document.getElementById("token").value = jwt;
 

--- a/public/form.html
+++ b/public/form.html
@@ -16,12 +16,18 @@
         </div>
 
         <div class="container mb-3">
-            <div class="d-flex">
-                <img id="avatar" class="rounded-circle" width="64" height="64" alt="Your avatar">
-                <h2 id="username" class="ml-3 mb-0 align-self-center"></h2>
+            <div class="flex-column justify-content-center">
+                <div class="d-flex">
+                    <img id="avatar" class="rounded-circle" width="70" height="70" alt="Your avatar">
+                    <h2 id="username" class="ml-3 mb-0 align-self-center"></h2>
+                </div>
+                <div id="banReasonContainer" class="mt-3">
+                    <b>Ban reason:</b>
+                    <span id="originalBanReason"></span>
+                </div>
             </div>
 
-            <form class="mt-3" method="post" name="appeal" action="/success" netlify>
+            <form class="mt-5" method="post" name="appeal" action="/success" netlify>
                 <input type="hidden" id="token" name="token">
                 <div class="form-group">
                     <label for="banReason">Why were you banned?</label>
@@ -72,6 +78,11 @@
             document.getElementById("avatar").src = `https://cdn.discordapp.com/${avatar}?size=256`;
 
             document.getElementById("username").textContent = userInfo.username;
+
+            if(userInfo.reason) {
+                document.getElementById("banReasonContainer").style.display = "block";
+                document.getElementById("originalBanReason").textContent = userInfo.reason;
+            }
 
             document.getElementById("token").value = jwt;
 

--- a/public/style.css
+++ b/public/style.css
@@ -177,3 +177,13 @@ textarea:focus {
 #username {
     color: white;
 }
+
+#banReasonContainer {
+    color: white;
+    display: none;
+}
+
+#originalBanReason {
+    color: #8e9297;
+    font-style: italic;
+}


### PR DESCRIPTION
By default, the ban reason is displayed until you set the `ALWAYS_HIDE_BAN_REASON` environment variable or use `/h` or `/hide` in the ban reason.

The `/p` and `/perm` flag was also added to prevent users from using ban appeal form.

![image](https://github.com/user-attachments/assets/6bb9dd88-13bd-40bd-9e87-ec260ea339c0)

This PR includes #86 however, they can be merged separately.
